### PR TITLE
Raise exception when no images are generated on a successful response

### DIFF
--- a/bing_create/main.py
+++ b/bing_create/main.py
@@ -92,8 +92,11 @@ class ImageGenerator:
                     break
 
             # Find and return image links
+            prev_len = len(images)
             images += ["https://tse" + link.split("?w=")[0] for link in re.findall(
                 'src="https://tse([^"]+)"', response.text)]
+            if len(images) == prev_len:
+                raise Exception("🛑 No new images were generated")
             self.__log(f"✅ Successfully finished cycle {cycle} in {round(time.time() - start_time, 2)} seconds")
 
         self.__log(

--- a/bing_create/main.py
+++ b/bing_create/main.py
@@ -17,7 +17,7 @@ class ImageGenerator:
 
     def __init__(self, auth_cookie_u: str, auth_cookie_srchhpgusr: str, logging_enabled: bool = True):
         # Setting up httpx client
-        self.client: httpx.Client() = httpx.Client(
+        self.client: httpx.Client = httpx.Client(
             cookies={
                 '_U': auth_cookie_u,
                 'SRCHHPGUSR': auth_cookie_srchhpgusr
@@ -136,7 +136,7 @@ class AsyncImageGenerator:
 
     def __init__(self, auth_cookie_u: str, auth_cookie_srchhpgusr: str, logging_enabled: bool = True):
         # Setting up httpx client
-        self.client: httpx.AsyncClient() = httpx.AsyncClient(
+        self.client: httpx.AsyncClient = httpx.AsyncClient(
             cookies={
                 '_U': auth_cookie_u,
                 'SRCHHPGUSR': auth_cookie_srchhpgusr

--- a/bing_create/main.py
+++ b/bing_create/main.py
@@ -92,11 +92,11 @@ class ImageGenerator:
                     break
 
             # Find and return image links
-            prev_len = len(images)
-            images += ["https://tse" + link.split("?w=")[0] for link in re.findall(
+            new_images = ["https://tse" + link.split("?w=")[0] for link in re.findall(
                 'src="https://tse([^"]+)"', response.text)]
-            if len(images) == prev_len:
-                raise Exception("🛑 No new images were generated")
+            if len(new_images) == 0:
+                raise Exception("🛑 No new images were generated for this cycle, please check your prompt")
+            images += new_images
             self.__log(f"✅ Successfully finished cycle {cycle} in {round(time.time() - start_time, 2)} seconds")
 
         self.__log(
@@ -211,8 +211,10 @@ class AsyncImageGenerator:
                     break
 
             # Find and return image links
-            images += ["https://tse" + link.split("?w=")[0] for link in re.findall(
+            new_images = ["https://tse" + link.split("?w=")[0] for link in re.findall(
                 'src="https://tse([^"]+)"', response.text)]
+            if len(new_images) == 0:
+                raise Exception("🛑 No new images were generated for this cycle, please check your prompt")
             self.__log(f"✅ Successfully finished cycle {cycle} in {round(time.time() - start_time, 2)} seconds")
 
         self.__log(


### PR DESCRIPTION
There are some instances when the response from bing looks ok, but no images are generated. I don't know if this is caused by the prompt (maybe the prompt is deemed unsafe). At least raising this exception makes it easier to handle.

BTW I'm using this package to generate images using a script, with the prompts coming from a LLM, so with this exception my script will automatically generate a new prompt and everything will work once again. At least that's my use case.

Thanks for you great work on this package, it's wonderful and really easy to use.