### PR TITLE
Remove dupilicate image urls from output

### DIFF
--- a/bing_create/main.py
+++ b/bing_create/main.py
@@ -92,8 +92,8 @@ class ImageGenerator:
                     break
 
             # Find and return image links
-            new_images = ["https://tse" + link.split("?w=")[0] for link in re.findall(
-                'src="https://tse([^"]+)"', response.text)]
+            new_images = list(dict.fromkeys(["https://tse" + link.split("?w=")[0] for link in re.findall(
+                'src="https://tse([^"]+)"', response.text)]))
             if len(new_images) == 0:
                 raise Exception("🛑 No new images were generated for this cycle, please check your prompt")
             images += new_images


### PR DESCRIPTION
Bing seems to be returning duplicate urls in the response which is also duplicating in the final url list output and not allowing download of all generated images.